### PR TITLE
Revert tranlations for spoof player parameter type

### DIFF
--- a/src/main/resources/youtube/translations/ar/strings.xml
+++ b/src/main/resources/youtube/translations/ar/strings.xml
@@ -600,14 +600,20 @@
     <string name="revanced_spoof_app_version_target_entry_title">الهدف من خِداع إصدار التطبيق</string>
     <string name="revanced_spoof_app_version_target_summary">اكتب هدف إصدار التطبيق المخادع</string>
     <string name="revanced_spoof_app_version_target_title">تعديل خِداع إصدار التطبيق</string>
-    <string name="revanced_spoof_player_parameter_summary">"لمنع مشاكل التشغيل Spoofs player parameters
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Player Parameters لمقاطع Shorts
 
 مشاكل معروفة
-• قد لا يعمل وضع الإضاءة السينمائية
-• لا يمكن تشغيل المقطع بشكل طبيعي
-• قد لا يعمل تنزيل مقاطع الفيديو
-• واجهة شريط الفيلم مخفية بشكل دائم
-• يتم إخفاء المعاينة المصغرة في شريط تقدم الفيديو"</string>
+- العلامة المائية للقناة مخفية دائمًا
+- قد لا يعمل تنزيل مقاطع الفيديو
+- بطاقات شاشة النهاية مخفية دائمًا"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Player Parameters في وضع التصفح المتخفي
+
+ مشاكل معروفة
+ - قد لا تعمل الإضاءة السينمائية
+ - قد لا يعمل تنزيل مقاطع الفيديو
+ - شريط تقدم المصغرات مخفي"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Spoof Player Parameter Type</string>
+    <string name="revanced_spoof_player_parameter_summary">Spoofs Player Parameters لمنع مشاكل التشغيل</string>
     <string name="revanced_spoof_player_parameter_title">Spoof Player Parameter</string>
     <string name="revanced_swipe_controls">التحكم عن طريق السحب</string>
     <string name="revanced_swipe_magnitude_threshold_summary">مقدار الحد الأدنى للتمرير قبل اكتشاف السحب 

--- a/src/main/resources/youtube/translations/bg-rBG/strings.xml
+++ b/src/main/resources/youtube/translations/bg-rBG/strings.xml
@@ -604,14 +604,20 @@
     <string name="revanced_spoof_app_version_target_entry_title">Подлъгване за исканата версията на приложението</string>
     <string name="revanced_spoof_app_version_target_summary">Задайте желаната фалшива версия на приложението</string>
     <string name="revanced_spoof_app_version_target_title">Редактиране на фалшивата версия</string>
-    <string name="revanced_spoof_player_parameter_summary">"Фалшифициране параметрите на плейъра за предотвратяване на проблеми при възпроизвеждане
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Параметри на плейъра за кратки клипове
 
 Известни проблеми
-• Околния режим може и да не работи
-• Клиповете може да не се възпроизвеждат нормално
-• Изтеклянето на клипове може да не работи
-• Филмовите ленти винаги се показват
-• Прегледа при превъртане не се показва"</string>
+ - Водния знак на канала е винаги скрит
+ - Изтеглянето на клипове може да не работи
+ - Крайните карти са винаги скрити"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Параметри на плейъра в таен режим
+
+Известни проблеми
+ - Околния режим може да не работи
+ - Изтеглянето на клипове може да не работи
+ - Прегледа във времевата лента е скрит"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Вид на фалшивия параметър на плейъра</string>
+    <string name="revanced_spoof_player_parameter_summary">Фалшифициране на параметрите н плейъра за отстраняване на проблеми с възпройзвеждането</string>
     <string name="revanced_spoof_player_parameter_title">Фалшив параметър на плейъра</string>
     <string name="revanced_swipe_controls">Плъзгащи контроли</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Праг преди да се осъществи плъзгането</string>

--- a/src/main/resources/youtube/translations/bn/strings.xml
+++ b/src/main/resources/youtube/translations/bn/strings.xml
@@ -604,14 +604,20 @@
     <string name="revanced_spoof_app_version_target_entry_title">স্পুফ অ্যাপ সংস্করণ টার্গেট</string>
     <string name="revanced_spoof_app_version_target_summary">আপনার নিজস্ব অ্যাপ স্পুফ সংস্করণ লিখুন</string>
     <string name="revanced_spoof_app_version_target_title">অ্যাপ সংস্করণ স্ফুপ সম্পাদনা করুন</string>
-    <string name="revanced_spoof_player_parameter_summary">"প্লেব্যাক ইস্যু সমাধান করতে প্লেয়ার প্যারামিটার স্পুফ করুন
+    <string name="revanced_spoof_player_parameter_type_summary_off">"শর্টস এর প্লেয়ার প্যারামিটার
 
 জানা সমস্যা
-• অ্যাম্বিয়েন্ট মোড কাজ নাও করতে পারে
-• ক্লিপ ঠিকমতো চলবে না
-• ভিডিও ডাউনলোড কাজ নাও করতে পারে
-• ফিল্মস্ট্রিপ ওভারলে সবসময় লুকিয়ে থাকবে
-• সিকবার থাম্বনেইল সবসময় লুকিয়ে থাকবে"</string>
+- চ্যানেল ওয়াটারমার্ক সবসময় লুকায়িত থাকবে
+- অফলাইন ভিডিও ডাউনলোড ঠিকমতো কাজ নাও করতে পারে
+- ভিডিওর শেষ স্ক্রীণের কার্ড সবসময় লুকায়িত থাকবে"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"ছদ্মবেশী মোডের প্লেয়ার প্যারামিটার
+
+জানা সমস্যা
+- অ্যাম্বিয়েন্ট মোড কাজ নাও করতে পারে
+- অফলাইন ভিডিও ডাউনলোড ঠিকমতো কাজ নাও করতে পারে
+- সিকবার থাম্বনেইল সবসময় লুকায়িত থাকে"</string>
+    <string name="revanced_spoof_player_parameter_type_title">প্লেয়ার প্যারামিটার স্পুফের ধরণ</string>
+    <string name="revanced_spoof_player_parameter_summary">প্লেব্যাক ইস্যু ঠিক করতে প্লেয়ার প্যারামিটার স্পুফ করে</string>
     <string name="revanced_spoof_player_parameter_title">প্লেয়ার প্যারামিটার স্পুফ করুন</string>
     <string name="revanced_swipe_controls">সোয়াইপ কন্ট্রোল</string>
     <string name="revanced_swipe_magnitude_threshold_summary">সোয়াইপ হওয়ার জন্য থ্রেশহোল্ডের পরিমাণ</string>

--- a/src/main/resources/youtube/translations/el-rGR/strings.xml
+++ b/src/main/resources/youtube/translations/el-rGR/strings.xml
@@ -608,15 +608,21 @@
     <string name="revanced_spoof_app_version_target_entry_title">Έκδοση της εφαρμογής που θα χρησιμοποιηθεί</string>
     <string name="revanced_spoof_app_version_target_summary">Πληκτρολογήστε την έκδοση εφαρμογής που θα εφαρμοστεί</string>
     <string name="revanced_spoof_app_version_target_title">Επεξεργασία έκδοσης εφαρμογής που θα εφαρμοθεί</string>
-    <string name="revanced_spoof_player_parameter_summary">"Αυτή η λειτουργία τροποποιεί τις παραμέτρους του αναπαραγωγέα για την αποφυγή προβλημάτων αναπαραγωγής
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Παράμετροι του αναπαραγωγέα Shorts
 
 Γνωστά προβλήματα
-• Η λειτουργία περιβάλλοντος ενδέχεται να μη λειτουργεί
-• Τα κλιπ ενδέχεται να μην παίζουν κανονικά
-• Η λήψη βίντεο ενδέχεται να μη λειτουργεί
-• Η ακριβής αναζήτηση στη γραμμή προόδου είναι πάντα απενεργοποιημένη
-• Η προεπισκόπηση μικρογραφιών στη γραμμή προόδου δεν εμφανίζεται"</string>
-    <string name="revanced_spoof_player_parameter_title">Τροποποίηση παραμέτρου αναπαραγωγέα</string>
+- Το υδατογράφημα καναλιού είναι πάντα κρυμμένο
+- Η λήψη βίντεο ενδέχεται να μην λειτουργεί
+- Οι κάρτες τελικής οθόνης είναι πάντα κρυμμένες"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Παράμετροι αναπαραγωγέα σε λειτουργία ινκόγκνιτο
+
+Γνωστά προβλήματα
+- Η λειτουργία περιβάλλοντος ενδέχεται να μην λειτουργεί
+- Η λήψη βίντεο ενδέχεται να μην λειτουργεί
+- Η προεπισκόπηση μικρογραφιών στη γραμμή προόδου δεν εμφανίζεται"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Τύπος παραμέτρου αναπαραγωγέα που θα παραποιηθεί</string>
+    <string name="revanced_spoof_player_parameter_summary">Αυτή η λειτουργία παραποιεί τις παραμέτρους του αναπαραγωγέα για την αποφυγή προβλημάτων αναπαραγωγής</string>
+    <string name="revanced_spoof_player_parameter_title">Παραποίηση παραμέτρου αναπαραγωγέα</string>
     <string name="revanced_swipe_controls">Έλεγχος με σάρωση οθόνης</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Ελάχιστο πλάτος κίνησης αναγνωρίσιμο ως χειρονομία σάρωσης</string>
     <string name="revanced_swipe_magnitude_threshold_title">Κατώτατο όριο μεγέθους σάρωσης</string>

--- a/src/main/resources/youtube/translations/es-rES/strings.xml
+++ b/src/main/resources/youtube/translations/es-rES/strings.xml
@@ -605,14 +605,20 @@ Si más tarde se desactiva, la antigua interfaz de usuario puede permanecer hast
     <string name="revanced_spoof_app_version_target_entry_title">Versión a usar de la aplicación</string>
     <string name="revanced_spoof_app_version_target_summary">Escriba la versión a modificar de la app</string>
     <string name="revanced_spoof_app_version_target_title">Modificar versión de aplicación</string>
-    <string name="revanced_spoof_player_parameter_summary">"Los parámetros del reproductor se modifican para evitar problemas de reproducción
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Parámetros del reproductor de Shorts
 
 Problemas conocidos
-- Es posible que el Modo Ambiente no funcione
-- El Clip no puede reproducirse normalmente
+- La marca de agua del canal siempre está oculta
 - La descarga de vídeos puede no funcionar
-- La superposición de la tira de película siempre está oculta
+- Las tarjetas de pantalla final siempre están ocultas"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Parámetros del reproductor en modo incógnito
+
+Problemas conocidos
+- El modo ambiente puede no funcionar
+- La descarga de vídeos puede no funcionar
 - Las miniaturas de la barra de progreso están ocultas"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Tipo de parámetro del reproductor a modificar</string>
+    <string name="revanced_spoof_player_parameter_summary">Modifica los parámetros del reproductor para evitar problemas de reproducción</string>
     <string name="revanced_spoof_player_parameter_title">Modificar parámetro del reproductor</string>
     <string name="revanced_swipe_controls">Controles deslizantes</string>
     <string name="revanced_swipe_magnitude_threshold_summary">La cantidad de umbral para que ocurra el deslizamiento</string>

--- a/src/main/resources/youtube/translations/fr-rFR/strings.xml
+++ b/src/main/resources/youtube/translations/fr-rFR/strings.xml
@@ -597,14 +597,20 @@ Ce paramètre étant obsolètes, il se peut qu'ils ne soient plus valables"</str
     <string name="revanced_spoof_app_version_target_entry_title">Falsifier la version de l\'application</string>
     <string name="revanced_spoof_app_version_target_summary">Tapez la version de l\'application à fausser</string>
     <string name="revanced_spoof_app_version_target_title">Falsifier la version de l\'application</string>
-    <string name="revanced_spoof_player_parameter_summary">"Paramètres du lecteur pour éviter les problèmes de lecture
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Paramètres des Shorts
 
 Problèmes connus
-• Le mode Ambiant peut ne pas fonctionner
-• L'extrait de la vidéo enregistré peut pas être lu normalement
-• Le téléchargement de vidéos peut ne pas fonctionner
-• Les bandes de films sont toujours cachée
-• La barre de progression sur les miniatures sont cachées"</string>
+- Le filigrane de la chaîne est toujours caché
+- Les téléchargements peuvent ne pas fonctionner
+- Les cartes de fin sont toujours cachées"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Paramètres du lecteur en mode navigation privée
+
+Problèmes connus
+- Le mode ambiant peut ne pas fonctionner
+- Les téléchargements peuvent ne pas fonctionner
+- La barre de progression sur la miniature est cachée"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Falsifier les paramètres du lecteur</string>
+    <string name="revanced_spoof_player_parameter_summary">Falsifier les paramètres du lecteur pour éviter les problèmes de lecture</string>
     <string name="revanced_spoof_player_parameter_title">Falsifier les paramètres du lecteur</string>
     <string name="revanced_swipe_controls">Commandes de balayage</string>
     <string name="revanced_swipe_magnitude_threshold_summary">L\'intensité de balayage correspond à la mesure de glissement utilisée pour ajuster le niveau sonore ou de luminosité</string>

--- a/src/main/resources/youtube/translations/hu-rHU/strings.xml
+++ b/src/main/resources/youtube/translations/hu-rHU/strings.xml
@@ -603,15 +603,6 @@ Ha később kikapcsolja, a régi felhasználói felület megmaradhat az alkalmaz
     <string name="revanced_spoof_app_version_target_entry_title">Hamis alkalmazásverzió-cél</string>
     <string name="revanced_spoof_app_version_target_summary">Írja be a hamis alkalmazásverzió célját</string>
     <string name="revanced_spoof_app_version_target_title">Szerkessze a hamis alkalmazás verzióját</string>
-    <string name="revanced_spoof_player_parameter_summary">"Meghamisítja a lejátszó paramétereit, hogy megakadályozza a lejátszási problémákat
-
-Ismert problémák
-• Előfordulhat, hogy a Mozifilmes világítás nem működik
-• A klipet nem lehet normálisan lejátszani
-• Előfordulhat, hogy a videók letöltése nem működik
-• A filmszalag fedőrétegei mindig rejtettek
-• A bélyegképek haladási sávja el van rejtve"</string>
-    <string name="revanced_spoof_player_parameter_title">Lejátszó paraméter hamisítása</string>
     <string name="revanced_swipe_controls">Csúsztatásos vezérlők</string>
     <string name="revanced_swipe_magnitude_threshold_summary">A csúsztatás küszöbértékének mértéke</string>
     <string name="revanced_swipe_magnitude_threshold_title">A csúsztatás küszöbértéke</string>

--- a/src/main/resources/youtube/translations/id-rID/strings.xml
+++ b/src/main/resources/youtube/translations/id-rID/strings.xml
@@ -603,14 +603,20 @@ Jika nanti dimatikan, UI lama mungkin tetap ada sampai menghapus data aplikasi"<
     <string name="revanced_spoof_app_version_target_entry_title">Palsukan target versi aplikasi</string>
     <string name="revanced_spoof_app_version_target_summary">Ketik versi target pemalsuan aplikasi</string>
     <string name="revanced_spoof_app_version_target_title">Edit pemalsuan versi aplikasi</string>
-    <string name="revanced_spoof_player_parameter_summary">"Memalsukan parameter pemutar untuk mencegah masalah pemutaran
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Parameter pemutar shorts
 
 Masalah yang diketahui
-• Mode pencahayaan sinematik mungkin tidak berfungsi
-• Klip tidak dapat diputar secara normal
-• Download video mungkin tidak berfungsi
-• Overlay strip film selalu disembunyikan
-• Thumbnail seekbar disembunyikan"</string>
+- Watermark channel selalu disembunyikan
+- Mendownload video mungkin tidak berfungsi
+- Kartu layar akhir selalu disembunyikan"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Parameter pemutar mode samaran
+
+Masalah yang diketahui
+- Mode pencahayaan sinematik mungkin tidak berfungsi
+- Download video mungkin tidak berfungsi
+- Thumbnail seekbar disembunyikan"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Jenis parameter pemutar untuk pemalsuan</string>
+    <string name="revanced_spoof_player_parameter_summary">Memalsukan parameter pemutar untuk mencegah masalah pemutaran</string>
     <string name="revanced_spoof_player_parameter_title">Parameter pemutar pemalsuan</string>
     <string name="revanced_swipe_controls">Kontrol swipe</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Jumlah ambang batas untuk swipe terjadi</string>

--- a/src/main/resources/youtube/translations/in/strings.xml
+++ b/src/main/resources/youtube/translations/in/strings.xml
@@ -603,14 +603,20 @@ Jika nanti dimatikan, UI lama mungkin tetap ada sampai menghapus data aplikasi"<
     <string name="revanced_spoof_app_version_target_entry_title">Palsukan target versi aplikasi</string>
     <string name="revanced_spoof_app_version_target_summary">Ketik versi target pemalsuan aplikasi</string>
     <string name="revanced_spoof_app_version_target_title">Edit pemalsuan versi aplikasi</string>
-    <string name="revanced_spoof_player_parameter_summary">"Memalsukan parameter pemutar untuk mencegah masalah pemutaran
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Parameter pemutar shorts
 
 Masalah yang diketahui
-• Mode pencahayaan sinematik mungkin tidak berfungsi
-• Klip tidak dapat diputar secara normal
-• Download video mungkin tidak berfungsi
-• Overlay strip film selalu disembunyikan
-• Thumbnail seekbar disembunyikan"</string>
+- Watermark channel selalu disembunyikan
+- Mendownload video mungkin tidak berfungsi
+- Kartu layar akhir selalu disembunyikan"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Parameter pemutar mode samaran
+
+Masalah yang diketahui
+- Mode pencahayaan sinematik mungkin tidak berfungsi
+- Download video mungkin tidak berfungsi
+- Thumbnail seekbar disembunyikan"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Jenis parameter pemutar untuk pemalsuan</string>
+    <string name="revanced_spoof_player_parameter_summary">Memalsukan parameter pemutar untuk mencegah masalah pemutaran</string>
     <string name="revanced_spoof_player_parameter_title">Parameter pemutar pemalsuan</string>
     <string name="revanced_swipe_controls">Kontrol swipe</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Jumlah ambang batas untuk swipe terjadi</string>

--- a/src/main/resources/youtube/translations/it-rIT/strings.xml
+++ b/src/main/resources/youtube/translations/it-rIT/strings.xml
@@ -604,14 +604,20 @@ Se verrà disattivato in seguito, la vecchia interfaccia potrebbe rimanere fino 
     <string name="revanced_spoof_app_version_target_entry_title">La versione dell\'app da simulare</string>
     <string name="revanced_spoof_app_version_target_summary">Digita la versione dell\'app da simulare</string>
     <string name="revanced_spoof_app_version_target_title">Modifica la versione dell\'app da simulare</string>
-    <string name="revanced_spoof_player_parameter_summary">"Simula il riproduttore per prevenire problemi di riproduzione.
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Parametri del riproduttore degli Shorts.
 
 Problemi noti:
-- La Modalità Ambient potrebbe non funzionare
-- I clip non possono essere riprodotti normalmente
-- Il download dei video potrebbe non funzionare
-- La sovrapposizione della pellicola è sempre nascosta
-- L'anteprima degli thumbnails della barra di avanzamento è sempre nascosta"</string>
+- Il watermark nei video è sempre nascosto
+- Il download di video potrebbe non funzionare
+- Le schede finali sono sempre nascoste"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Parametri del riproduttore della navigazione in incognito.
+
+Problemi noti:
+- La modalità Ambient potrebbe non funzionare
+- Il download di video potrebbe non funzionare
+- L'anteprima degli thumbnails della barra di avanzamento è nascosta"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Simula il tipo di parametri del riproduttore</string>
+    <string name="revanced_spoof_player_parameter_summary">Simula i parametri del riproduttore per prevenire problemi di riproduzione</string>
     <string name="revanced_spoof_player_parameter_title">Simula i parametri del riproduttore</string>
     <string name="revanced_swipe_controls">Controlli a scorrimento</string>
     <string name="revanced_swipe_magnitude_threshold_summary">La quantità di interazioni prima che lo scorrimento si verifichi</string>

--- a/src/main/resources/youtube/translations/ja-rJP/strings.xml
+++ b/src/main/resources/youtube/translations/ja-rJP/strings.xml
@@ -604,14 +604,19 @@
     <string name="revanced_spoof_app_version_target_entry_title">偽装するバージョンを選択</string>
     <string name="revanced_spoof_app_version_target_summary">偽装したいバージョンを入力してください</string>
     <string name="revanced_spoof_app_version_target_title">偽装するアプリのバージョンを編集する</string>
-    <string name="revanced_spoof_player_parameter_summary">"プレーヤーのパラメータを偽装して、バッファリングの問題を修正します
+    <string name="revanced_spoof_player_parameter_type_summary_off">"YouTubeショートのプレーヤーのパラメータ
+既知の問題：
+‐ 動画の右下のウォーターマークは表示されません
+‐ 動画のダウンロードに失敗することがあります
+‐ 動画の終了画面のカードは表示されません"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"シークレットモードのプレイヤーパラメータ
 
- 既知の問題点
- • アンビエントモードが機能しない可能性があります
- • クリップが正常に再生できません
- • 動画のダウンロードが機能しない可能性があります
- • 再生バー(シークバー)長押しで表示される映写スライドは非表示になります
- • シークバーのサムネイルが非表示になります"</string>
+既知の問題
+- アンビエントモードが動作しない場合があります
+- 動画のダウンロードが動作しない場合があります
+- シークバーに表示されるサムネイルが非表示になります"</string>
+    <string name="revanced_spoof_player_parameter_type_title">偽装するプレーヤーのパラメータの種類を選択</string>
+    <string name="revanced_spoof_player_parameter_summary">バッファリングの問題を修正するために、プレーヤーのパラメータを偽装します</string>
     <string name="revanced_spoof_player_parameter_title">偽装するプレーヤーのパラメータの種類を選択</string>
     <string name="revanced_swipe_controls">スワイプコントロール</string>
     <string name="revanced_swipe_magnitude_threshold_summary">スワイプのしきい値を設定します</string>

--- a/src/main/resources/youtube/translations/ko-rKR/strings.xml
+++ b/src/main/resources/youtube/translations/ko-rKR/strings.xml
@@ -605,14 +605,20 @@ YouTube 18.24.37 버전 이상에서만 적용 가능합니다."</string>
     <string name="revanced_spoof_app_version_target_entry_title">변경할 앱 버전 설정</string>
     <string name="revanced_spoof_app_version_target_summary">변경할 앱 버전을 입력하세요.</string>
     <string name="revanced_spoof_app_version_target_title">변경할 앱 버전 편집하기</string>
-    <string name="revanced_spoof_player_parameter_summary">"플레이어 매개변수를 변경하여 재생 문제를 방지합니다.
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Shorts의 플레이어 매개변수로 변경합니다.
+
+알려진 문제점
+- 채널 워터마크가 항상 숨겨집니다.
+- 오프라인 저장이 작동하지 않을 수 있습니다.
+- 최종 화면 카드가 항상 숨겨집니다."</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"시크릿 모드의 플레이어 매개변수로 변경합니다.
 
 알려진 문제점
 - 영화 조명 모드가 작동하지 않을 수 있습니다.
-- 클립이 정상적으로 재생되지 않습니다.
 - 오프라인 저장이 작동하지 않을 수 있습니다.
-- 필름 스트립 오버레이가 항상 숨겨집니다.
 - 재생바 썸네일이 숨겨집니다."</string>
+    <string name="revanced_spoof_player_parameter_type_title">변경할 플레이어 매개변수 설정</string>
+    <string name="revanced_spoof_player_parameter_summary">플레이어 매개변수를 변경하여 재생 문제를 방지합니다.</string>
     <string name="revanced_spoof_player_parameter_title">플레이어 매개변수 변경하기</string>
     <string name="revanced_swipe_controls">스와이프 제스처</string>
     <string name="revanced_swipe_magnitude_threshold_summary">제스처 인식을 위해 얼마나 스와이프를 해야 할지를 설정할 수 있으며, 원하지 않은 제스처 인식을 방지합니다.</string>

--- a/src/main/resources/youtube/translations/pl-rPL/strings.xml
+++ b/src/main/resources/youtube/translations/pl-rPL/strings.xml
@@ -603,14 +603,20 @@ Jeśli później opcja ta zostanie wyłączona, stare UI może pozostać do czas
     <string name="revanced_spoof_app_version_target_entry_title">Oszukana wersja aplikacji</string>
     <string name="revanced_spoof_app_version_target_summary">Wpisz wersję, którą chcesz oszukiwać</string>
     <string name="revanced_spoof_app_version_target_title">Zmień oszukaną wersję aplikacji</string>
-    <string name="revanced_spoof_player_parameter_summary">"Oszukuje parametry, by zapobiec problemom z odtwarzaniem
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Parametry Shortów
 
 Znane problemy
-• Oświetlenie kinowe może nie działać
-• Nie można zobaczyć klipów normalnie
-• Pobieranie wideo może nie działać
-• Precyzyjniejsze przesuwanie po pasku nie działa
-• Podgląd wideo nie działa"</string>
+- Znaki wodne kanałów są ukryte
+- Pobieranie wideo może nie działać
+- Karty końcowe wideo są ukryte"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Parametry trybu incognito
+
+Znane problemy
+- Oświetlnie kinowe może nie działać
+- Pobieranie wideo może nie działać
+- Podgląd wideo jest wyłączony"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Oszukane parametry</string>
+    <string name="revanced_spoof_player_parameter_summary">Oszukuje parametry, by uniknąć problemów z odtwarzaniem wideo</string>
     <string name="revanced_spoof_player_parameter_title">Oszukaj parametry</string>
     <string name="revanced_swipe_controls">Sterowanie przesuwaniem</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Minimalna długość przesunięcia</string>

--- a/src/main/resources/youtube/translations/pt-rBR/strings.xml
+++ b/src/main/resources/youtube/translations/pt-rBR/strings.xml
@@ -604,14 +604,20 @@ Se mais tarde for desligado, a interface do usuário antiga poderá permanecer a
     <string name="revanced_spoof_app_version_target_entry_title">Versão da falsificação do aplicativo</string>
     <string name="revanced_spoof_app_version_target_summary">Digite a versão do app para falsificação</string>
     <string name="revanced_spoof_app_version_target_title">Editar versão de falsificação do app</string>
-    <string name="revanced_spoof_player_parameter_summary">"Disfarça parâmetros do player para prevenir problemas de reprodução
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Parâmetros do reprodutor de Shorts
 
 Problemas conhecidos
-• Modo ambiente pode não funcionar
-• Clip pode não ser reproduzido normalmente
-• Baixar vídeos pode não funcionar
-• Sobreposição de Filmstrip são sempre ocultas
-• Miniaturas da barra de busca estão ocultas"</string>
+- A marca d'água do canal é sempre escondida
+- Baixar vídeos pode não funcionar
+- Os cartões de tela finais são sempre ocultos"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Parâmetros do player de modo incógnito
+
+Problemas conhecidos
+- Modo ambiente pode não funcionar
+- Baixar vídeos pode não funcionar
+- As miniaturas da Barra de Busca estão ocultas"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Tipo de parâmetro de falsificação do player</string>
+    <string name="revanced_spoof_player_parameter_summary">Parâmetros de player falsificados para previnir o problema de reprodução</string>
     <string name="revanced_spoof_player_parameter_title">Parâmetro de falsificação do player</string>
     <string name="revanced_swipe_controls">Controles por gestos</string>
     <string name="revanced_swipe_magnitude_threshold_summary">A distância a ser percorrida pelo gesto de deslizar</string>

--- a/src/main/resources/youtube/translations/ru-rRU/strings.xml
+++ b/src/main/resources/youtube/translations/ru-rRU/strings.xml
@@ -602,14 +602,20 @@
     <string name="revanced_spoof_app_version_target_entry_title">Целевая версия приложения при подмене</string>
     <string name="revanced_spoof_app_version_target_summary">Введите целевую версию приложения для подмены</string>
     <string name="revanced_spoof_app_version_target_title">Подмена версии приложения</string>
-    <string name="revanced_spoof_player_parameter_summary">"Подмена параметров плеера для предотвращения проблем с воспроизведением
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Параметры плеера \"Shorts\"
 
 Известные проблемы:
-• Режим фоновой подсветки может не работать
-• Клипы нормально не воспроизводятся
-• Загрузка видео может не работать
-• Покадровая лента в стиле \"старой кинопленки\" всегда скрыта
-• Миниатюры прогресса воспроизведения скрыты"</string>
+- Логотип канала всегда скрыт
+- Скачивание видео может не работать
+- Конечные заставки всегда скрыты"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Параметры плеера в режиме инкогнито
+
+Известные проблемы:
+- Фоновая подсветка может не работать
+- Загрузка видео может не работать
+- Миниатюры прогресса воспроизведения скрыты"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Тип подмены параметров плеера</string>
+    <string name="revanced_spoof_player_parameter_summary">Подменяет параметры плеера для предотвращения проблем с воспроизведением видео</string>
     <string name="revanced_spoof_player_parameter_title">Подмена параметров плеера</string>
     <string name="revanced_swipe_controls">Жесты</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Минимальная амплитуда распознаваемого как жест движения</string>

--- a/src/main/resources/youtube/translations/tr-rTR/strings.xml
+++ b/src/main/resources/youtube/translations/tr-rTR/strings.xml
@@ -600,14 +600,20 @@ Bu, uygulamanın görünümünü değiştirir, ancak bilinmeyen yan etkiler orta
     <string name="revanced_spoof_app_version_target_entry_title">Uygulama hedef sürümünü kandır</string>
     <string name="revanced_spoof_app_version_target_summary">Sahte uygulama sürümü hedefini yazın</string>
     <string name="revanced_spoof_app_version_target_title">Kandırılmış uygulama sürümünü düzenle</string>
-    <string name="revanced_spoof_player_parameter_summary">"Oynatma sorunlarını önlemek için oynatıcı parametrelerini taklit eder
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Shorts'un oynatıcı parametreleri
 
 Bilinen sorunlar
-• Ambiyans modu çalışmayabilir
-• Klip normal şekilde oynatılamaz
-• Videoları indirmek çalışmayabilir
-• Film şeridi kaplaması her zaman gizlidir
-• Arama çubuğu küçük resimleri gizlenir"</string>
+-Kanal filigranı her zaman gizlidir
+-Video indirme çalışmayabilir
+-Video bitiş kartları her zaman gizlidir"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Gizli modun oynatıcı parametreleri
+
+Bilinen sorunlar 
+-Ambiyans modu çalışmayabilir
+-Video indirme çalışmayabilir
+-Zaman çubuğu küçük resimleri gizlidir"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Sahte oynatıcı parametre türü</string>
+    <string name="revanced_spoof_player_parameter_summary">Oynatma sorununu çözmek için sahte oynatıcı parametreleri</string>
     <string name="revanced_spoof_player_parameter_title">Sahte oynatıcı parametresi</string>
     <string name="revanced_swipe_controls">Kaydırma kontrolleri</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Kaydırma işleminin gerçekleşmesi için eşik miktarı</string>

--- a/src/main/resources/youtube/translations/uk-rUA/strings.xml
+++ b/src/main/resources/youtube/translations/uk-rUA/strings.xml
@@ -603,15 +603,21 @@
     <string name="revanced_spoof_app_version_target_entry_title">Підробити цільову версію програми</string>
     <string name="revanced_spoof_app_version_target_summary">Введіть цільову версію підробки програми</string>
     <string name="revanced_spoof_app_version_target_title">Редагувати підробку версії програми</string>
-    <string name="revanced_spoof_player_parameter_summary">"Підроблення параметрів плеєра для виправлення проблем відтворення
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Параметри плеєра Шортів
 
 Відомі проблеми
-- Фонова підсвітка може не працювати
-- Кліп не може нормально відтворюватися
+- Водяний знак каналу завжди приховано
 - Завантаження відео може не працювати
-- Покадрову перемотку завжди приховано
-- Мініатюри панелі прогресу приховано"</string>
-    <string name="revanced_spoof_player_parameter_title">Підробити параметр плеєра</string>
+- Картки кінцевого екрану завжди приховані"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Параметри плеєра в режимі інкогніто
+
+Відомі проблеми
+- Може не працювати фонова підсвітка
+- Завантаження відео може не працювати
+- Панель прогресу приховано"</string>
+    <string name="revanced_spoof_player_parameter_type_title">Підмінити тип параметра плеєра</string>
+    <string name="revanced_spoof_player_parameter_summary">Підмінити параметри плеєра для виправлення проблем відтворення</string>
+    <string name="revanced_spoof_player_parameter_title">Підмінити параметр плеєра</string>
     <string name="revanced_swipe_controls">Керування жестами</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Мінімальна амплітуда руху, що розпізнається як жест</string>
     <string name="revanced_swipe_magnitude_threshold_title">Поріг величини жесту</string>

--- a/src/main/resources/youtube/translations/vi-rVN/strings.xml
+++ b/src/main/resources/youtube/translations/vi-rVN/strings.xml
@@ -604,12 +604,20 @@ Lưu ý:
     <string name="revanced_spoof_app_version_target_entry_title">Phiên bản giả mạo</string>
     <string name="revanced_spoof_app_version_target_summary">Nhập phiên bản YouTube mà bạn muốn giả mạo</string>
     <string name="revanced_spoof_app_version_target_title">Chỉnh sửa phiên bản giả mạo</string>
-    <string name="revanced_spoof_player_parameter_summary">"Giả mạo thông số trình phát để khắc phục vấn đề giật hình khi phát video.
+    <string name="revanced_spoof_player_parameter_type_summary_off">"Thông số của trình phát Shorts.
 
 Sự cố đã biết:
-- Chế độ môi trường xung quanh, Tua chính xác và Tải video xuống để xem khi không có mạng có thể không hoạt động.
-- Đoạn video không thể phát bình thường.
-- Thanh tiến trình trong hình thu nhỏ video luôn ẩn."</string>
+- Hình mờ video luôn ẩn.
+- Màn hình kết thúc luôn ẩn.
+- Tải video xuống để xem khi không có mạng có thể không hoạt động."</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"Thông số của trình phát ở chế độ ẩn danh.
+
+Sự cố đã biết:
+- Chế độ môi trường xung quanh có thể không hoạt động.
+- Tải video xuống để xem khi không có mạng có thể không hoạt động.
+- Thanh tiến trình trong hình thu nhỏ luôn ẩn."</string>
+    <string name="revanced_spoof_player_parameter_type_title">Loại thông số của trình phát giả mạo</string>
+    <string name="revanced_spoof_player_parameter_summary">Giả mạo thông số của trình phát để khắc phục vấn đề giật hình khi phát video</string>
     <string name="revanced_spoof_player_parameter_title">Giả mạo thông số trình phát</string>
     <string name="revanced_swipe_controls">Điều khiển bằng cử chỉ vuốt</string>
     <string name="revanced_swipe_magnitude_threshold_summary">Độ rộng của ngưỡng vuốt để thực hiện cử chỉ vuốt</string>

--- a/src/main/resources/youtube/translations/zh-rCN/strings.xml
+++ b/src/main/resources/youtube/translations/zh-rCN/strings.xml
@@ -590,14 +590,20 @@
     <string name="revanced_spoof_app_version_target_entry_title">伪装应用版本</string>
     <string name="revanced_spoof_app_version_target_summary">选择伪装的应用版本</string>
     <string name="revanced_spoof_app_version_target_title">编辑伪装应用版本</string>
-    <string name="revanced_spoof_player_parameter_summary">"伪装播放器参数以回避播放问题
+    <string name="revanced_spoof_player_parameter_type_summary_off">"短视频的播放器参数
 
 已知问题
-• 可能无法使用氛围模式
-• 剪辑无法正常播放
-• 可能无法下载视频
-• 影片横条总是被隐藏
-• 进度条缩略图被隐藏"</string>
+- 频道水印总是隐藏
+- 可能无法下载视频
+- 结束画面卡片总是隐藏"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"无痕模式的播放器参数
+
+已知问题
+- 氛围模式可能无效
+- 可能无法下载视频
+- 进度条预览被隐藏"</string>
+    <string name="revanced_spoof_player_parameter_type_title">伪装播放器参数形式</string>
+    <string name="revanced_spoof_player_parameter_summary">伪装播放器参数以回避播放问题</string>
     <string name="revanced_spoof_player_parameter_title">伪装播放器参数</string>
     <string name="revanced_swipe_controls">滑动控制</string>
     <string name="revanced_swipe_magnitude_threshold_summary">防误触的滑动幅度阈值</string>

--- a/src/main/resources/youtube/translations/zh-rTW/strings.xml
+++ b/src/main/resources/youtube/translations/zh-rTW/strings.xml
@@ -604,14 +604,20 @@
     <string name="revanced_spoof_app_version_target_entry_title">欺騙應用程式版本目標</string>
     <string name="revanced_spoof_app_version_target_summary">輸入欺騙的應用程式版本目標</string>
     <string name="revanced_spoof_app_version_target_title">編輯欺騙應用程式版本</string>
-    <string name="revanced_spoof_player_parameter_summary">"為了避免播放問題，這個應用程式對播放器的參數進行了欺騙。
+    <string name="revanced_spoof_player_parameter_type_summary_off">"短片播放器參數
 
 已知問題：
-• 環境模式可能無法運作
-• 不能正常播放片段
-• 下載影片可能無法運作
-• 電影帶疊加畫面始終被隱藏
-• 搜尋軸縮略圖被隱藏"</string>
+- 頻道浮水印始終隱藏
+- 下載影片可能無法運作
+- 結尾畫面卡片始終隱藏"</string>
+    <string name="revanced_spoof_player_parameter_type_summary_on">"隱身模式的播放器參數
+
+已知問題
+- 環境模式可能無法正常運作
+- 下載影片可能無法正常運作
+- 搜尋條縮圖被隱藏"</string>
+    <string name="revanced_spoof_player_parameter_type_title">欺騙播放器參數類型</string>
+    <string name="revanced_spoof_player_parameter_summary">欺騙播放器參數以避免播放問題</string>
     <string name="revanced_spoof_player_parameter_title">欺騙播放器參數</string>
     <string name="revanced_swipe_controls">滑動控制</string>
     <string name="revanced_swipe_magnitude_threshold_summary">滑動時調整的數值量</string>


### PR DESCRIPTION
Continuation of [this commit](https://github.com/YT-Advanced/ReX-patches/commit/bd7b6785a239f903ba5b3ae6a8d606f639767702), where the [same thing was done](https://github.com/YT-Advanced/ReX-patches/commit/bd7b6785a239f903ba5b3ae6a8d606f639767702#diff-f8970a96a6eb5a39df2e5d5d094cd60834128fc7ed46ccdca40730a99cab50fb) but only for default strings.xml