### PR TITLE
fix(YouTube) Update strings.xml

### DIFF
--- a/src/main/resources/youtube/settings/host/values/strings.xml
+++ b/src/main/resources/youtube/settings/host/values/strings.xml
@@ -47,8 +47,8 @@ Tap here to learn more about DeArrow."</string>
     <string name="revanced_append_time_stamp_information_summary_off">Append time stamp information is disabled.</string>
     <string name="revanced_append_time_stamp_information_summary_on">Append time stamp information is enabled.</string>
     <string name="revanced_append_time_stamp_information_title">Append time stamp information</string>
-    <string name="revanced_append_time_stamp_information_type_summary_off">Append playback speed.</string>
-    <string name="revanced_append_time_stamp_information_type_summary_on">Append video quality.</string>
+    <string name="revanced_append_time_stamp_information_type_summary_off">Append playback speed. Tap and hold on timestamp to change the type while playing the video.</string>
+    <string name="revanced_append_time_stamp_information_type_summary_on">Append video quality. Tap and hold on timestamp to change the type while playing the video.</string>
     <string name="revanced_append_time_stamp_information_type_title">Append information type</string>
     <string name="revanced_bottom_player">Bottom player</string>
     <string name="revanced_button_container_title">Button container</string>
@@ -441,8 +441,18 @@ Some components may not be hidden."</string>
     <string name="revanced_hide_get_premium_summary_off">YouTube Premium promotion is shown.</string>
     <string name="revanced_hide_get_premium_summary_on">YouTube Premium promotion is hidden.</string>
     <string name="revanced_hide_get_premium_title">Hide YouTube Premium promotion</string>
-    <string name="revanced_hide_gray_description_summary_off">Gray description is shown.</string>
-    <string name="revanced_hide_gray_description_summary_on">Gray description is hidden.</string>
+    <string name="revanced_hide_gray_description_summary_off">Gray description is shown.
+
+Gray description refers to:
+• From your Watch Later playlist.
+• People also watched this video.
+• Channel viewers also watch this channel, etc.</string>
+    <string name="revanced_hide_gray_description_summary_on">Gray description is hidden.
+
+Gray description refers to:
+• From your Watch Later playlist.
+• People also watched this video.
+• Channel viewers also watch this channel, etc.</string>
     <string name="revanced_hide_gray_description_title">Hide gray description</string>
     <string name="revanced_hide_gray_separator_summary_off">Gray separators are shown.</string>
     <string name="revanced_hide_gray_separator_summary_on">Gray separators are hidden.</string>
@@ -739,8 +749,8 @@ Tap and hold to copy video timestamp."</string>
     <string name="revanced_overlay_button_external_downloader_title">Show external download button</string>
     <string name="revanced_overlay_button_time_ordered_playlist_summary">"Tap to generate a playlist of all videos from channel from oldest to newest.
 Tap and hold to undo."</string>
-    <string name="revanced_overlay_button_time_ordered_playlist_title">Time-ordered Playlist Button</string>
-    <string name="revanced_overlay_button_speed_dialog_reset">Playback speed reseted (1.0x).</string>
+    <string name="revanced_overlay_button_time_ordered_playlist_title">Time-ordered playlist button</string>
+    <string name="revanced_overlay_button_speed_dialog_reset">Playback speed reset (1.0x).</string>
     <string name="revanced_overlay_button_speed_dialog_summary">"Tap to open speed dialog.
 Tap and hold to set playback speed to 1.0x."</string>
     <string name="revanced_overlay_button_speed_dialog_title">Show speed dialog button</string>


### PR DESCRIPTION
In the case of `Time-ordered playlist button` it would be more consistent to add "Show" > `Show time-ordered playlist button`, because all strings for Overlay Buttons start with "Show". But for me, it would be better to remove "Show" from all of them.